### PR TITLE
Inject dependencies instead of using getEpic

### DIFF
--- a/src/__tests__/epic.js
+++ b/src/__tests__/epic.js
@@ -42,7 +42,7 @@ test('Happy path', marbles(m => {
   const expected$ = m.cold('-------------xy-----|', values);
 
   const getAjaxObservable = jest.fn().mockReturnValueOnce(
-    of({response: { content: contentAsBase64}}).pipe(delay(1)),
+    of({response: { content: contentAsBase64}}).pipe(delay(1))
   );
 
   // Inject `dueTime` and `TestScheduler` into epic:
@@ -178,3 +178,4 @@ it('Should dispatch "fetch fail" action when retries are unsuccessful due to 404
   m.expect(actual$).toBeObservable(expected$);
 
 }));
+

--- a/src/__tests__/epic.js
+++ b/src/__tests__/epic.js
@@ -47,7 +47,7 @@ test('Happy path', marbles(m => {
 
   // Inject `dueTime` and `TestScheduler` into epic:
   const actual$ = epic(action$, state$, {
-    ajaxMethod: getAjaxObservable,
+    getAjax: getAjaxObservable,
     dueTime: 4,
     scheduler: m.scheduler,
   });
@@ -72,7 +72,7 @@ test('Should dispatch error message when invalid URL is entered', marbles(m => {
 
   const actual$ = epic(action$, state$, {
     // This mock will not be called so it doesn't matter what value it returns
-    ajaxMethod: jest.fn(),
+    getAjax: jest.fn(),
     dueTime: 4,
     scheduler: m.scheduler,
   });
@@ -104,7 +104,7 @@ test('Should show initial state when user clears input field', marbles(m => {
   );
 
   const actual$ = epic(action$, state$, {
-    ajaxMethod: testAjax,
+    getAjax: testAjax,
     dueTime: 4,
     scheduler: m.scheduler,
   });
@@ -138,7 +138,7 @@ it('Should retry when encountering fetch error', marbles(m => {
   const expected$ = m.cold('-------------(xy)---|', values);
 
   const actual$ = epic(action$, state$, {
-    ajaxMethod: getTestAjaxObservable,
+    getAjax: getTestAjaxObservable,
     dueTime: 4,
     scheduler: m.scheduler,
   });
@@ -171,7 +171,7 @@ it('Should dispatch "fetch fail" action when retries are unsuccessful due to 404
   const expected$ = m.cold('-------------(xz)---|', values);
 
   const actual$ = epic(action$, state$, {
-    ajaxMethod: getTestAjaxObservable,
+    getAjax: getTestAjaxObservable,
     dueTime: 4,
     scheduler: m.scheduler,
   });

--- a/src/epic.ts
+++ b/src/epic.ts
@@ -41,79 +41,82 @@ const isUpdateURLAction = (action: Action): action is UpdateURLAction =>
 export type FetchOutcome = FetchInitialAction | FetchBeginAction |
                             FetchSuccessAction | FetchFailAction;
 
-export const getEpic = (
-    // These arguments allow for dependency injection during testing:
-    getAjax: typeof ajax = ajax,
-    dueTime: number = 250,
-    // Note: `undefined` scheduler passed to `debounceTime` in production means
-    // it'll use the "natural" scheduler:
-    scheduler: Scheduler | undefined = undefined,
-  ): Epic<Action, RootState, {}, FetchOutcome> =>
-    (action$: Observable<Action>, state$: Observable<RootState>) =>
-      action$.pipe(
-        filter<Action, UpdateURLAction>(isUpdateURLAction),
-        debounceTime(dueTime, scheduler),
-        withLatestFrom(state$),
-        switchMap<[UpdateURLAction, RootState], FetchOutcome>(([, {url}]): Observable<FetchOutcome> => {
-          if (url === '') {
-            // If the user input is blank, show the initial prompt:
-            return of<FetchInitialAction>({type: ActionTypes.FETCH_INITIAL});
+export interface EpicDependencies {
+  ajaxMethod: typeof ajax;
+  dueTime: number;
+  scheduler?: Scheduler;
+}
+
+export const epic: Epic<Action, RootState, EpicDependencies, FetchOutcome> =
+  (action$: Observable<Action>, state$: Observable<RootState>, {
+    ajaxMethod = ajax,
+    dueTime = 250,
+    scheduler,
+  }: EpicDependencies) =>
+    action$.pipe(
+      filter<Action, UpdateURLAction>(isUpdateURLAction),
+      debounceTime(dueTime, scheduler),
+      withLatestFrom(state$),
+      switchMap<[UpdateURLAction, RootState], FetchOutcome>(([, {url}]): Observable<FetchOutcome> => {
+        if (url === '') {
+          // If the user input is blank, show the initial prompt:
+          return of<FetchInitialAction>({type: ActionTypes.FETCH_INITIAL});
+        } else {
+          const parseResult = parse(url);
+          if (parseResult === null) {
+            // If we cannot parse the URL into a GitHub URL at all, show an error message:
+            return of<FetchFailAction>({type: ActionTypes.FETCH_FAIL, payload: {message: 'Invalid GitHub URL'}});
           } else {
-            const parseResult = parse(url);
-            if (parseResult === null) {
-              // If we cannot parse the URL into a GitHub URL at all, show an error message:
-              return of<FetchFailAction>({type: ActionTypes.FETCH_FAIL, payload: {message: 'Invalid GitHub URL'}});
+            // Otherwise, initiate a fetch:
+            const fetchBegin$ = of<FetchBeginAction>({type: ActionTypes.FETCH_BEGIN});
+            const {branch, path, repo, user} = parseResult;
+            const fetchURL = `https://api.github.com/repos/${user}/${repo}/contents/${path}?ref=${branch}`;
+
+            let ajaxRequest: AjaxRequest;
+            // Note: `GITHUB_TOKEN` will be replaced with a string
+            // value by webpack's `DefinePlugin`:
+            if (GITHUB_TOKEN === undefined) {
+              // If no github token is provided, send an unauthenticated request:
+              ajaxRequest = {
+                url: fetchURL,
+              };
             } else {
-              // Otherwise, initiate a fetch:
-              const fetchBegin$ = of<FetchBeginAction>({type: ActionTypes.FETCH_BEGIN});
-              const {branch, path, repo, user} = parseResult;
-              const fetchURL = `https://api.github.com/repos/${user}/${repo}/contents/${path}?ref=${branch}`;
-
-              let ajaxRequest: AjaxRequest;
-              // Note: `GITHUB_TOKEN` will be replaced with a string
-              // value by webpack's `DefinePlugin`:
-              if (GITHUB_TOKEN === undefined) {
-                // If no github token is provided, send an unauthenticated request:
-                ajaxRequest = {
-                  url: fetchURL,
-                };
-              } else {
-                // Otherwise, send credentials along to avoid rate limit:
-                ajaxRequest = {
-                  url: fetchURL,
-                  headers: {
-                    Authorization: `token ${GITHUB_TOKEN}`,
-                  },
-                };
-              }
-
-              const fetchPipeline$ = getAjax(ajaxRequest).pipe(
-                retry<AjaxResponse>(3),
-                map<AjaxResponse, FetchSuccessAction>(({response}) => {
-                  if (Array.isArray(response)) {
-                    // This means the fetched URL is a directory instead
-                    // of a file:
-                    throw new Error('URL is a GitHub directory instead of a file');
-                  }
-                  const {content} = response;
-                  const decoded = atob(content);
-                  return {type: ActionTypes.FETCH_SUCCESS, payload: {data: decoded}};
-                }),
-                catchError<any, FetchFailAction>((err: AjaxError) => {
-                  // Try to use error message in ajax response because we assume
-                  // it's more relevant that the `message` property of the `err`
-                  // observable:
-                  let message: string;
-                  if (err.xhr && err.xhr.response && err.xhr.response.message) {
-                    message = err.xhr.response.message;
-                  } else {
-                    message = err.message;
-                  }
-                  return of<FetchFailAction>({type: ActionTypes.FETCH_FAIL, payload: {message}});
-                }),
-              );
-              return concat(fetchBegin$, fetchPipeline$);
+              // Otherwise, send credentials along to avoid rate limit:
+              ajaxRequest = {
+                url: fetchURL,
+                headers: {
+                  Authorization: `token ${GITHUB_TOKEN}`,
+                },
+              };
             }
+
+            const fetchPipeline$ = ajaxMethod(ajaxRequest).pipe(
+              retry<AjaxResponse>(3),
+              map<AjaxResponse, FetchSuccessAction>(({response}) => {
+                if (Array.isArray(response)) {
+                  // This means the fetched URL is a directory instead
+                  // of a file:
+                  throw new Error('URL is a GitHub directory instead of a file');
+                }
+                const {content} = response;
+                const decoded = atob(content);
+                return {type: ActionTypes.FETCH_SUCCESS, payload: {data: decoded}};
+              }),
+              catchError<any, FetchFailAction>((err: AjaxError) => {
+                // Try to use error message in ajax response because we assume
+                // it's more relevant that the `message` property of the `err`
+                // observable:
+                let message: string;
+                if (err.xhr && err.xhr.response && err.xhr.response.message) {
+                  message = err.xhr.response.message;
+                } else {
+                  message = err.message;
+                }
+                return of<FetchFailAction>({type: ActionTypes.FETCH_FAIL, payload: {message}});
+              }),
+            );
+            return concat(fetchBegin$, fetchPipeline$);
           }
-        }),
-      );
+        }
+      }),
+    );

--- a/src/epic.ts
+++ b/src/epic.ts
@@ -49,8 +49,11 @@ export interface EpicDependencies {
 
 export const epic: Epic<Action, RootState, EpicDependencies, FetchOutcome> =
     (action$: Observable<Action>, state$: Observable<RootState>, {
+      // These arguments allow for dependency injection during testing:
       getAjax = ajax,
       dueTime = 250,
+      // Note: `undefined` scheduler passed to `debounceTime` in production means
+      // it'll use the "natural" scheduler:
       scheduler,
     }: EpicDependencies) =>
       action$.pipe(

--- a/src/epic.ts
+++ b/src/epic.ts
@@ -42,14 +42,14 @@ export type FetchOutcome = FetchInitialAction | FetchBeginAction |
                             FetchSuccessAction | FetchFailAction;
 
 export interface EpicDependencies {
-  ajaxMethod: typeof ajax;
+  getAjax: typeof ajax;
   dueTime: number;
   scheduler?: Scheduler;
 }
 
 export const epic: Epic<Action, RootState, EpicDependencies, FetchOutcome> =
   (action$: Observable<Action>, state$: Observable<RootState>, {
-    ajaxMethod = ajax,
+    getAjax = ajax,
     dueTime = 250,
     scheduler,
   }: EpicDependencies) =>
@@ -90,7 +90,7 @@ export const epic: Epic<Action, RootState, EpicDependencies, FetchOutcome> =
               };
             }
 
-            const fetchPipeline$ = ajaxMethod(ajaxRequest).pipe(
+            const fetchPipeline$ = getAjax(ajaxRequest).pipe(
               retry<AjaxResponse>(3),
               map<AjaxResponse, FetchSuccessAction>(({response}) => {
                 if (Array.isArray(response)) {

--- a/src/epic.ts
+++ b/src/epic.ts
@@ -42,81 +42,81 @@ export type FetchOutcome = FetchInitialAction | FetchBeginAction |
                             FetchSuccessAction | FetchFailAction;
 
 export interface EpicDependencies {
-  getAjax: typeof ajax;
-  dueTime: number;
+  getAjax?: typeof ajax;
+  dueTime?: number;
   scheduler?: Scheduler;
 }
 
 export const epic: Epic<Action, RootState, EpicDependencies, FetchOutcome> =
-  (action$: Observable<Action>, state$: Observable<RootState>, {
-    getAjax = ajax,
-    dueTime = 250,
-    scheduler,
-  }: EpicDependencies) =>
-    action$.pipe(
-      filter<Action, UpdateURLAction>(isUpdateURLAction),
-      debounceTime(dueTime, scheduler),
-      withLatestFrom(state$),
-      switchMap<[UpdateURLAction, RootState], FetchOutcome>(([, {url}]): Observable<FetchOutcome> => {
-        if (url === '') {
-          // If the user input is blank, show the initial prompt:
-          return of<FetchInitialAction>({type: ActionTypes.FETCH_INITIAL});
-        } else {
-          const parseResult = parse(url);
-          if (parseResult === null) {
-            // If we cannot parse the URL into a GitHub URL at all, show an error message:
-            return of<FetchFailAction>({type: ActionTypes.FETCH_FAIL, payload: {message: 'Invalid GitHub URL'}});
+    (action$: Observable<Action>, state$: Observable<RootState>, {
+      getAjax = ajax,
+      dueTime = 250,
+      scheduler,
+    }: EpicDependencies) =>
+      action$.pipe(
+        filter<Action, UpdateURLAction>(isUpdateURLAction),
+        debounceTime(dueTime, scheduler),
+        withLatestFrom(state$),
+        switchMap<[UpdateURLAction, RootState], FetchOutcome>(([, {url}]): Observable<FetchOutcome> => {
+          if (url === '') {
+            // If the user input is blank, show the initial prompt:
+            return of<FetchInitialAction>({type: ActionTypes.FETCH_INITIAL});
           } else {
-            // Otherwise, initiate a fetch:
-            const fetchBegin$ = of<FetchBeginAction>({type: ActionTypes.FETCH_BEGIN});
-            const {branch, path, repo, user} = parseResult;
-            const fetchURL = `https://api.github.com/repos/${user}/${repo}/contents/${path}?ref=${branch}`;
-
-            let ajaxRequest: AjaxRequest;
-            // Note: `GITHUB_TOKEN` will be replaced with a string
-            // value by webpack's `DefinePlugin`:
-            if (GITHUB_TOKEN === undefined) {
-              // If no github token is provided, send an unauthenticated request:
-              ajaxRequest = {
-                url: fetchURL,
-              };
+            const parseResult = parse(url);
+            if (parseResult === null) {
+              // If we cannot parse the URL into a GitHub URL at all, show an error message:
+              return of<FetchFailAction>({type: ActionTypes.FETCH_FAIL, payload: {message: 'Invalid GitHub URL'}});
             } else {
-              // Otherwise, send credentials along to avoid rate limit:
-              ajaxRequest = {
-                url: fetchURL,
-                headers: {
-                  Authorization: `token ${GITHUB_TOKEN}`,
-                },
-              };
-            }
+              // Otherwise, initiate a fetch:
+              const fetchBegin$ = of<FetchBeginAction>({type: ActionTypes.FETCH_BEGIN});
+              const {branch, path, repo, user} = parseResult;
+              const fetchURL = `https://api.github.com/repos/${user}/${repo}/contents/${path}?ref=${branch}`;
 
-            const fetchPipeline$ = getAjax(ajaxRequest).pipe(
-              retry<AjaxResponse>(3),
-              map<AjaxResponse, FetchSuccessAction>(({response}) => {
-                if (Array.isArray(response)) {
-                  // This means the fetched URL is a directory instead
-                  // of a file:
-                  throw new Error('URL is a GitHub directory instead of a file');
-                }
-                const {content} = response;
-                const decoded = atob(content);
-                return {type: ActionTypes.FETCH_SUCCESS, payload: {data: decoded}};
-              }),
-              catchError<any, FetchFailAction>((err: AjaxError) => {
-                // Try to use error message in ajax response because we assume
-                // it's more relevant that the `message` property of the `err`
-                // observable:
-                let message: string;
-                if (err.xhr && err.xhr.response && err.xhr.response.message) {
-                  message = err.xhr.response.message;
-                } else {
-                  message = err.message;
-                }
-                return of<FetchFailAction>({type: ActionTypes.FETCH_FAIL, payload: {message}});
-              }),
-            );
-            return concat(fetchBegin$, fetchPipeline$);
+              let ajaxRequest: AjaxRequest;
+              // Note: `GITHUB_TOKEN` will be replaced with a string
+              // value by webpack's `DefinePlugin`:
+              if (GITHUB_TOKEN === undefined) {
+                // If no github token is provided, send an unauthenticated request:
+                ajaxRequest = {
+                  url: fetchURL,
+                };
+              } else {
+                // Otherwise, send credentials along to avoid rate limit:
+                ajaxRequest = {
+                  url: fetchURL,
+                  headers: {
+                    Authorization: `token ${GITHUB_TOKEN}`,
+                  },
+                };
+              }
+
+              const fetchPipeline$ = getAjax(ajaxRequest).pipe(
+                retry<AjaxResponse>(3),
+                map<AjaxResponse, FetchSuccessAction>(({response}) => {
+                  if (Array.isArray(response)) {
+                    // This means the fetched URL is a directory instead
+                    // of a file:
+                    throw new Error('URL is a GitHub directory instead of a file');
+                  }
+                  const {content} = response;
+                  const decoded = atob(content);
+                  return {type: ActionTypes.FETCH_SUCCESS, payload: {data: decoded}};
+                }),
+                catchError<any, FetchFailAction>((err: AjaxError) => {
+                  // Try to use error message in ajax response because we assume
+                  // it's more relevant that the `message` property of the `err`
+                  // observable:
+                  let message: string;
+                  if (err.xhr && err.xhr.response && err.xhr.response.message) {
+                    message = err.xhr.response.message;
+                  } else {
+                    message = err.message;
+                  }
+                  return of<FetchFailAction>({type: ActionTypes.FETCH_FAIL, payload: {message}});
+                }),
+              );
+              return concat(fetchBegin$, fetchPipeline$);
+            }
           }
-        }
-      }),
-    );
+        }),
+      );


### PR DESCRIPTION
Noticed you were using your own getEpic function to handle dependencies when its a built in feature of epics to pass an object of dependencies as the 3rd arg. 

Thought I'd throw this out there

P.S. Thanks for the great article on marble testing!